### PR TITLE
Fixed toggling power using cli-test.py

### DIFF
--- a/cli-test.py
+++ b/cli-test.py
@@ -39,10 +39,10 @@ for residence in all_residences:
             attribs['brightness'] = decora_bright
         if decora_cmd == 'ON':
             print('ON!')
-            attribs['POWER'] = 'ON'
+            attribs['power'] = 'ON'
         else:
             print('OFF!')
-            attribs['POWER'] = 'OFF'
+            attribs['power'] = 'OFF'
         switch.update_attributes(attribs)
 
 Person.logout(session)


### PR DESCRIPTION
Incorrect casing of "POWER" in the JSON sent to the light switch prevents the action from being recognised by the light switch. Changed to "power" to make it work.