### PR TITLE
Fix login errors with shared residences

### DIFF
--- a/cli-test.py
+++ b/cli-test.py
@@ -3,6 +3,7 @@
 from decora_wifi import DecoraWiFiSession
 from decora_wifi.models.person import Person
 from decora_wifi.models.residential_account import ResidentialAccount
+from decora_wifi.models.residence import Residence
 import sys
 
 
@@ -23,11 +24,17 @@ session.login(decora_email, decora_pass)
 # Gather all the available devices...
 
 perms = session.user.get_residential_permissions()
+print('{} premissions'.format(len(perms)))
 all_residences = []
 for permission in perms:
     print("Permission: {}".format(permission))
-    acct = ResidentialAccount(session, permission.residentialAccountId)
-    for res in acct.get_residences():
+    if permission.residentialAccountId is not None:
+        acct = ResidentialAccount(session, permission.residentialAccountId)
+        for res in acct.get_residences():
+            print("Residence: {}".format(res))
+            all_residences.append(res)
+    elif permission.residenceId is not None:
+        res = Residence(session, permission.residenceId)
         print("Residence: {}".format(res))
         all_residences.append(res)
 all_switches = []


### PR DESCRIPTION
My Leviton residence is shared with one of my roommates, and they're the primary account holder.

I was getting this error when trying to run the cli-test tool:

```
Permission: {'invitationId': XXXX, 'personId': 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX', 'status': 'active', 'residentialAccountId': None, 'created': '2018-05-10T05:26:26.000Z', 'residenceId': XXXX, 'id': XXXX, 'access': 'admin', 'lastUpdated': None}
myLeviton API call (/ResidentialAccounts/None/residences) failed: 401, {"error":{"statusCode":401,"name":"Error","message":"Authorization Required"}}
```

It looks like the `residentialAccountId` isn't populated for shared accounts, and `residenceId` is populated instead. This fix detects that scenario and creates the appropriate `Residence` object, which seems to work.