### PR TITLE
Avoid login loop

### DIFF
--- a/decora_wifi/__init__.py
+++ b/decora_wifi/__init__.py
@@ -50,7 +50,7 @@ class DecoraWiFiSession:
         # Unauthorized
         if response.status_code == 401 or response.status_code == 403:
             # Maybe we got logged out? Let's try logging in.
-            if self.login(self._email, self._password) is None:
+            if api == '/Person/login' or self.login(self._email, self._password) is None:
                 raise AuthExpiredError("Auth expired and unable to refresh")
             # Retry the request...
             response = getattr(self._session, method)(uri, data=payload_json)


### PR DESCRIPTION
If a login fails and returns a 401/403, it will try to login right away. This is causing the users to get locked out. 

This fix will not retry a login with the same bad credentials if a login fails.