### PR TITLE
Add 15sec request timeout to all API calls, fixing indefinite hangs

### DIFF
--- a/decora_wifi/__init__.py
+++ b/decora_wifi/__init__.py
@@ -17,6 +17,7 @@ class DecoraWiFiSession:
     """This class represents an authorized HTTPS session with the LCS API."""
 
     LEVITON_ROOT = 'https://my.leviton.com/api'
+    REQUEST_TIMEOUT_SECS = 15
 
     def __init__(self):
         """Initialize the session, all content is JSON."""
@@ -45,7 +46,10 @@ class DecoraWiFiSession:
         else:
             payload_json = ''
 
-        response = getattr(self._session, method)(uri, data=payload_json)
+        response = getattr(self._session, method)(
+            uri,
+            data=payload_json,
+            timeout=self.REQUEST_TIMEOUT_SECS)
 
         # Unauthorized
         if response.status_code == 401 or response.status_code == 403:
@@ -53,7 +57,10 @@ class DecoraWiFiSession:
             if api == '/Person/login' or self.login(self._email, self._password) is None:
                 raise AuthExpiredError("Auth expired and unable to refresh")
             # Retry the request...
-            response = getattr(self._session, method)(uri, data=payload_json)
+            response = getattr(self._session, method)(
+                uri,
+                data=payload_json,
+                timeout=self.REQUEST_TIMEOUT_SECS)
 
         if response.status_code != 200 and response.status_code != 204:
             msg = "myLeviton API call ({0}) failed: {1}, {2}".format(


### PR DESCRIPTION
## Objective
This PR adds a 15 second timeout to all API requests to Leviton. As per the [`requests` lib docs](https://requests.readthedocs.io/en/latest/user/quickstart/#timeouts), a call may hang indefinitely without a timeout. A timeout will improve the reliability of always-on applications of the decora_wifi lib.

## Motivation
I use this library as part of homeassistant. I have found very rarely (once every 2 months or so) that the decora_wifi integration can break. Attaching a python debugger, I find a worker thread stuck indefinitely in the following stacktrace:

```
read (ssl.py:1134)
recv_into (ssl.py:1278)
readinto (socket.py:706)
_update_chunk_length (response.py:758)
read_chunked (response.py:828)
stream (response.py:624)
generate (models.py:816)
content (models.py:899)
send (sessions.py:747)
request (sessions.py:589)
get (sessions.py:602)
call_api (__init__.py:48)
refresh (iot_switch.py:87)
update (homeassistant/components/decora_wifi/light.py:172)
run (thread.py:58)
_worker (thread.py:83)
run (threading.py:975)
_bootstrap_inner (threading.py:1038)
_bootstrap (threading.py:995)
```

With this PR, I believe the flaky `call_api()` would timeout instead of getting stuck, and the following homeassistant update loop would hopefully succeed.

## Implementation
15 seconds should surely be enough for any call. I looked if I could attach a timeout to the `requests.Session`, but that appears to [not be possible](https://requests.readthedocs.io/en/latest/_modules/requests/sessions/#Session).